### PR TITLE
Specify Emscripten Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.t
 tar xzvf emsdk-portable.tar.gz
 cd emsdk-portable
 ./emsdk update
-./emsdk install latest
-./emsdk activate latest
+./emsdk install node-8.9.1-64bit && ./emsdk install emscripten-1.35.0 && ./emsdk install clang-tag-e1.35.0-64bit
+./emsdk activate node-8.9.1-64bit && ./emsdk activate emscripten-1.35.0 && ./emsdk activate clang-tag-e1.35.0-64bit
 source ./emsdk_env.sh
 
 cd /root # or /home/whatever


### PR DESCRIPTION
Temporary fixes for Kagami/ffmpeg.js#67, Kagami/ffmpeg.js#70, by relying on older emscripten build tools. This should be a temporary workaround until the build scripts are updated for later emscripten and clang builds.