### PR TITLE
Add new message for ffmpeg.js web worker to know the reason for aborting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ffmpeg.js also provides wrapper for main function with Web Worker interface to o
 * `{type: "exit", data: "<code>"}` - FFmpeg exited.
 * `{type: "done", data: "<result>"}` - Job finished with some result.
 * `{type: "error", data: "<error description>"}` - Error occurred.
+* `{type: "abort", data: "<abort reason>"}` - FFmpeg terminated abnormally (e.g. out of memory, wasm error).
 
 You can send the following messages to the worker:
 * `{type: "run", ...opts}` - Start new job with provided options.

--- a/build/post-worker.js
+++ b/build/post-worker.js
@@ -31,6 +31,9 @@ self.onmessage = function(e) {
       opts["onExit"] = function(code) {
         self.postMessage({"type": "exit", "data": code});
       };
+      opts["onAbort"] = function(reason) {
+        self.postMessage({"type": "abort", "data": reason});
+      };
       // TODO(Kagami): Should we wrap this function into try/catch in
       // case of possible exception?
       var result = __ffmpegjs(opts);


### PR DESCRIPTION
If an FFmpeg worker currently crashes with an abort, you can find the reason in the console, but this is not programmatically readable. This change adds another message type (`abort') which will send directly before the `exit' message to know the internal reason for the failure. With this information, the calling program code can now make adjustments to avoid causing the same error again.